### PR TITLE
Add Cockpit admin user and plugins

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,24 +1,28 @@
 # Use the official Debian base image
 FROM debian:stable-slim
 
-# Set the working directory
-WORKDIR /app
+ENV DEBIAN_FRONTEND=noninteractive
 
-# Expose port 9090
+# Environment variables for the cockpit admin user
+ENV COCKPIT_USER=cockpitadmin \
+    COCKPIT_PASSWORD=secret
+
+# Install Cockpit and all plugin packages, along with sudo
+RUN apt-get update && \
+    apt-get install -y sudo \
+        cockpit cockpit-389-ds cockpit-bridge cockpit-doc \
+        cockpit-machines cockpit-networkmanager cockpit-packagekit \
+        cockpit-pcp cockpit-podman cockpit-sosreport cockpit-storaged \
+        cockpit-system cockpit-tests cockpit-ws && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create a user for Cockpit with sudo privileges
+RUN useradd -m -s /bin/bash $COCKPIT_USER && \
+    echo "$COCKPIT_USER:$COCKPIT_PASSWORD" | chpasswd && \
+    usermod -aG sudo $COCKPIT_USER
+
+# Cockpit listens on port 9090
 EXPOSE 9090
 
-# Adduser
-# RUN adduser traver
-
-
-# Update package lists, upgrade, and install packages
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y cockpit \
-                       cockpit-storaged \
-                       cockpit-networkmanager \
-                       cockpit-packagekit \
-                       cockpit-machines \
-                       cockpit-podman \
-                       cockpit-sosreport \
-                       cockpit-pcp
+# Start the Cockpit web service
+CMD ["/usr/libexec/cockpit-ws"]


### PR DESCRIPTION
## Summary
- install all Cockpit plugins on Debian
- add environment variables for the Cockpit user and password
- create a sudo-enabled admin user for Cockpit

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864647a835083239061483bc02a3e2e