### PR TITLE
Add GitHub workflow for container publish

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -1,0 +1,38 @@
+name: Build and Publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image tag
+        id: vars
+        run: echo "TAG=$(date +'%m.%d.%Y')" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.TAG }}
+            ghcr.io/${{ github.repository }}:latest
+          file: dockerfile


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and publish the Docker image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68646951e65483238d13d2a66dcce3aa