### PR TITLE
Refine workflow for manual runs

### DIFF
--- a/.github/workflows/docker_build_publish.yml
+++ b/.github/workflows/docker_build_publish.yml
@@ -1,0 +1,41 @@
+name: Build and Publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare variables
+        id: vars
+        run: |
+          echo "DATE_TAG=$(date +'%m.%d.%Y')" >> "$GITHUB_OUTPUT"
+          echo "IMAGE=ghcr.io/${{ github.repository }}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: dockerfile
+          push: true
+          tags: |
+            ${{ steps.vars.outputs.IMAGE }}:${{ steps.vars.outputs.DATE_TAG }}
+            ${{ steps.vars.outputs.IMAGE }}:latest
+


### PR DESCRIPTION
## Summary
- rename workflow to `docker_build_publish.yml`
- include `workflow_dispatch` trigger for manual execution

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68646951e65483238d13d2a66dcce3aa