### PR TITLE
Prevent service start during build

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Run the following command from the repository root. The Dockerfile is named `doc
 docker build -t my-cockpit -f dockerfile .
 ```
 
+The Docker build temporarily installs a `policy-rc.d` script to prevent services
+like `pcp` from starting during installation. This avoids errors when building
+without systemd running and is cleaned up before the image is finalized.
+
 You can customize the username and password at build time by passing build arguments:
 
 ```bash

--- a/dockerfile
+++ b/dockerfile
@@ -13,7 +13,8 @@ WORKDIR /app
 EXPOSE 9090
 
 # Install Cockpit and required packages
-RUN apt-get update && \
+RUN echo '#!/bin/sh\nexit 101' > /usr/sbin/policy-rc.d && chmod +x /usr/sbin/policy-rc.d && \
+    apt-get update && \
     apt-get install -y curl gnupg systemd systemd-sysv dbus sudo passwd \
                        cockpit \
                        cockpit-storaged \
@@ -23,6 +24,7 @@ RUN apt-get update && \
                        cockpit-podman \
                        cockpit-sosreport \
                        cockpit-pcp && \
+    rm /usr/sbin/policy-rc.d && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- avoid apt failures when installing packages
- document that a temporary policy-rc.d script disables service start

## Testing
- `apt-get install -s cockpit`

------
https://chatgpt.com/codex/tasks/task_e_686489ceeadc8323a995301e2466691b